### PR TITLE
Add `mapOnce` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ state().mapDistinct { foo }
 ```
 
 
+### Observable.mapOnce
+Map to one property of the state and ensure
+that only the first value is observed
+
+```kotlin
+state().mapOnce { foo }
+  .subscribe { println(it) }
+
+// --> foo // completes after one value
+```
+
+
 ### Observable.mapOptional
 Map to one nullable property of the state and wrap in `Optional`
 
@@ -99,7 +111,7 @@ then filter for `Some` and ensure that only the first value is observed
 state().mapSomeOnce { bar }
   .subscribe { println(it) }
 
-// --> initialized // skips `None` and unsubscribes after one emission
+// --> initialized // skips `None` and completes after one emission
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ state().mapSomeOnce { bar }
 ## Binaries
 ```gradle
 dependencies {
-    implementation "cc.femto:rx-mapping-extensions:0.1"
+    implementation "cc.femto:rx-mapping-extensions:0.2"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.github.hpost'
-version '0.1'
+version '0.2'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/cc/femto/rx/extensions/Mapping.kt
+++ b/src/main/kotlin/cc/femto/rx/extensions/Mapping.kt
@@ -19,6 +19,20 @@ inline fun <T, R : Any> Observable<T>.mapDistinct(crossinline mapper: T.() -> R)
     this.map { mapper(it) }.distinctUntilChanged()
 
 /**
+ * Map the stream to the value returned from [mapper] and then
+ * apply [Observable.take] with value `1` to ensure the stream will
+ * complete after emitting one value
+ *
+ * Usage:
+ * <code>
+ *   stream.mapOnce { foo }
+ *     .subscribe { /* access at most one value */ }
+ * </code>
+ */
+inline fun <T, R : Any> Observable<T>.mapOnce(crossinline mapper: T.() -> R): Observable<R> =
+    this.map { mapper(it) }.take(1)
+
+/**
  * Map the stream to the value returned from [mapper], which is wrapped in an [Optional]
  *
  * Usage:
@@ -63,7 +77,7 @@ inline fun <T, R : Any> Observable<T>.mapSomeDistinct(crossinline mapper: T.() -
 
 /**
  * Applies [mapSome] and then [Observable.take] with value `1` to ensure
- * the stream will complete after emit the value in [mapper] once
+ * the stream will complete after emitting the value in [mapper] once
  *
  * Usage:
  * <code>

--- a/src/test/kotlin/cc/femto/rx/extensions/MappingSpec.kt
+++ b/src/test/kotlin/cc/femto/rx/extensions/MappingSpec.kt
@@ -37,6 +37,25 @@ class MappingSpec : Spek({
         }
     }
 
+    describe("mapOnce") {
+        lateinit var observer: TestObserver<String>
+
+        beforeEachTest {
+            state = Observable.just(
+                State(),
+                State(bar = "initialized"),
+                State(foo = "changed")
+            )
+            observer = state.mapOnce { foo }.test()
+        }
+
+        it("maps to property and completes after one emission") {
+            observer.assertValues(
+                "foo"
+            )
+        }
+    }
+
     describe("mapOptional") {
         lateinit var observer: TestObserver<Optional<String>>
 
@@ -110,7 +129,7 @@ class MappingSpec : Spek({
             observer = state.mapSomeOnce { bar }.test()
         }
 
-        it("maps to nullable property, wraps in `Optional`, filters for `Some` and unsubscribes after one emission") {
+        it("maps to nullable property, wraps in `Optional`, filters for `Some` and completes after one emission") {
             observer.assertValues(
                 "initialized"
             )


### PR DESCRIPTION
Maps to one property of the state and ensures that only the first value is observed